### PR TITLE
Add input for filtering by demo names / demo unit names

### DIFF
--- a/src/ReshowcaseUi.re
+++ b/src/ReshowcaseUi.re
@@ -69,6 +69,29 @@ module DemoSidebar = {
       );
   };
 
+  module MenuItem = {
+    [@react.component]
+    let make = (~demoName, ~demoUnits) =>
+      <div key=demoName>
+        <div style=Styles.demoName> demoName->React.string </div>
+        <div style=Styles.subList>
+          {demoUnits
+           ->Map.String.keysToArray
+           ->Array.map(demoUnitName =>
+               <div key=demoUnitName>
+                 <Link
+                   style=Styles.link
+                   activeStyle=Styles.activeLink
+                   href={"/" ++ demoName ++ "/" ++ demoUnitName}
+                   text=demoUnitName
+                 />
+               </div>
+             )
+           ->React.array}
+        </div>
+      </div>;
+  };
+
   let isBlank = s => Js.String.trim(s) == "";
 
   let hasSubstring = (s, ~substring) =>
@@ -90,33 +113,16 @@ module DemoSidebar = {
         />
         {demos
          ->Map.String.toArray
-         ->Array.keepMap(((demoName, demoUnits)) =>
-             if (filterValue->isBlank
-                 || demoName->hasSubstring(~substring=filterValue)) {
-               Some(
-                 <div key=demoName>
-                   <div style=Styles.demoName> demoName->React.string </div>
-                   <div style=Styles.subList>
-                     {demoUnits
-                      ->Map.String.keysToArray
-                      ->Array.map(demoUnitName =>
-                          <div key=demoUnitName>
-                            <Link
-                              style=Styles.link
-                              activeStyle=Styles.activeLink
-                              href={"/" ++ demoName ++ "/" ++ demoUnitName}
-                              text=demoUnitName
-                            />
-                          </div>
-                        )
-                      ->React.array}
-                   </div>
-                 </div>,
-               );
+         ->Array.keepMap(((demoName, demoUnits)) => {
+             let demoNameHasSubstring =
+               demoName->hasSubstring(~substring=filterValue);
+
+             if (filterValue->isBlank || demoNameHasSubstring) {
+               Some(<MenuItem demoName demoUnits />);
              } else {
                None;
-             }
-           )
+             };
+           })
          ->React.array}
       </div>
     </div>;

--- a/src/ReshowcaseUi.re
+++ b/src/ReshowcaseUi.re
@@ -91,6 +91,21 @@ module DemoSidebar = {
       </div>;
   };
 
+  module InputFilter = {
+    [@react.component]
+    let make = (~value, ~onChange) => {
+      <div
+        style={ReactDOMRe.Style.make(~padding="10px", ~display="flex", ())}>
+        <input
+          style={ReactDOMRe.Style.make(~padding="5px", ~width="100%", ())}
+          placeholder="Filter"
+          value
+          onChange
+        />
+      </div>;
+    };
+  };
+
   let hasSubstring = (s, ~substring) =>
     s->Js.String2.toLowerCase->Js.String2.includes(substring);
 
@@ -100,7 +115,7 @@ module DemoSidebar = {
 
     <div style=Styles.container>
       <div>
-        <input
+        <InputFilter
           value=filterValue
           onChange={event =>
             setFilterValue(_ =>

--- a/src/ReshowcaseUi.re
+++ b/src/ReshowcaseUi.re
@@ -35,6 +35,8 @@ module Link = {
 };
 
 module DemoSidebar = {
+  module String = Js.String2;
+
   module Styles = {
     let container =
       ReactDOMRe.Style.make(
@@ -92,22 +94,67 @@ module DemoSidebar = {
   };
 
   module InputFilter = {
-    [@react.component]
-    let make = (~value, ~onChange) => {
-      <div
-        style={ReactDOMRe.Style.make(~padding="10px", ~display="flex", ())}>
-        <input
-          style={ReactDOMRe.Style.make(~padding="5px", ~width="100%", ())}
-          placeholder="Filter"
-          value
-          onChange
-        />
-      </div>;
+    module Styles = {
+      let buttonClear =
+        ReactDOM.Style.make(
+          ~position="absolute",
+          ~right="15px",
+          ~display="flex",
+          ~cursor="pointer",
+          ~border="none",
+          ~padding="0",
+          ~backgroundColor="transparent",
+          (),
+        );
+
+      let inputWrapper =
+        ReactDOM.Style.make(
+          ~position="relative",
+          ~padding="10px",
+          ~display="flex",
+          ~alignItems="center",
+          (),
+        );
+
+      let input =
+        ReactDOMRe.Style.make(
+          ~padding="5px",
+          ~paddingRight="20px",
+          ~width="100%",
+          (),
+        );
     };
+
+    module ButtonClear = {
+      let iconClose =
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 18 18">
+          <path
+            fill="gray"
+            d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+          />
+        </svg>;
+
+      [@react.component]
+      let make = (~onClear) =>
+        <button style=Styles.buttonClear onClick={_event => onClear()}>
+          iconClose
+        </button>;
+    };
+
+    [@react.component]
+    let make = (~value, ~onChange, ~onClear) =>
+      <div style=Styles.inputWrapper>
+        <input style=Styles.input placeholder="Filter" value onChange />
+        <ButtonClear onClear />
+      </div>;
   };
 
-  let hasSubstring = (s, ~substring) =>
-    s->Js.String2.toLowerCase->Js.String2.includes(substring);
+  let hasSubstring = (string, ~substring) =>
+    string->String.toLowerCase->String.includes(substring);
 
   [@react.component]
   let make = (~demos) => {
@@ -119,17 +166,18 @@ module DemoSidebar = {
           value=filterValue
           onChange={event =>
             setFilterValue(_ =>
-              event->ReactEvent.Form.target##value->Js.String2.toLowerCase
+              event->ReactEvent.Form.target##value->String.toLowerCase
             )
           }
+          onClear={() => setFilterValue(_ => "")}
         />
         {demos
          ->Map.String.toArray
          ->Array.keepMap(((demoName, demoUnits)) => {
              let demoUnitNames = demoUnits->Map.String.keysToArray;
 
-             if (filterValue->Js.String2.trim == "") {
-               Some(<MenuItem demoName demoUnitNames />);
+             if (filterValue->String.trim == "") {
+               Some(<MenuItem key=demoName demoName demoUnitNames />);
              } else {
                let demoNameHasSubstring =
                  demoName->hasSubstring(~substring=filterValue);
@@ -139,11 +187,16 @@ module DemoSidebar = {
                  );
                switch (demoNameHasSubstring, filteredDemoUnitNames) {
                | (false, [||]) => None
-               | (true, [||]) => Some(<MenuItem demoName demoUnitNames />)
+               | (true, [||]) =>
+                 Some(<MenuItem key=demoName demoName demoUnitNames />)
                | (true, _)
                | (false, _) =>
                  Some(
-                   <MenuItem demoName demoUnitNames=filteredDemoUnitNames />,
+                   <MenuItem
+                     key=demoName
+                     demoName
+                     demoUnitNames=filteredDemoUnitNames
+                   />,
                  )
                };
              };

--- a/src/ReshowcaseUi.re
+++ b/src/ReshowcaseUi.re
@@ -68,31 +68,54 @@ module DemoSidebar = {
         (),
       );
   };
+
+  let isBlank = s => Js.String.trim(s) == "";
+
+  let hasSubstring = (s, ~substring) =>
+    s->Js.String2.toLowerCase->Js.String2.includes(substring);
+
   [@react.component]
   let make = (~demos) => {
+    let (filterValue, setFilterValue) = React.useState(() => "");
+
     <div style=Styles.container>
       <div>
+        <input
+          value=filterValue
+          onChange={event =>
+            setFilterValue(_ =>
+              event->ReactEvent.Form.target##value->Js.String.toLowerCase
+            )
+          }
+        />
         {demos
          ->Map.String.toArray
-         ->Array.map(((demoName, demoUnits)) =>
-             <div key=demoName>
-               <div style=Styles.demoName> demoName->React.string </div>
-               <div style=Styles.subList>
-                 {demoUnits
-                  ->Map.String.keysToArray
-                  ->Array.map(demoUnitName =>
-                      <div key=demoUnitName>
-                        <Link
-                          style=Styles.link
-                          activeStyle=Styles.activeLink
-                          href={"/" ++ demoName ++ "/" ++ demoUnitName}
-                          text=demoUnitName
-                        />
-                      </div>
-                    )
-                  ->React.array}
-               </div>
-             </div>
+         ->Array.keepMap(((demoName, demoUnits)) =>
+             if (filterValue->isBlank
+                 || demoName->hasSubstring(~substring=filterValue)) {
+               Some(
+                 <div key=demoName>
+                   <div style=Styles.demoName> demoName->React.string </div>
+                   <div style=Styles.subList>
+                     {demoUnits
+                      ->Map.String.keysToArray
+                      ->Array.map(demoUnitName =>
+                          <div key=demoUnitName>
+                            <Link
+                              style=Styles.link
+                              activeStyle=Styles.activeLink
+                              href={"/" ++ demoName ++ "/" ++ demoUnitName}
+                              text=demoUnitName
+                            />
+                          </div>
+                        )
+                      ->React.array}
+                   </div>
+                 </div>,
+               );
+             } else {
+               None;
+             }
            )
          ->React.array}
       </div>


### PR DESCRIPTION
## Description
Add input for filtering by demo names/demo unit names.
In a big codebase with hundreds of components and variations filtering is a very useful feature.

![image](https://user-images.githubusercontent.com/31879115/112383901-ca630180-8cfe-11eb-83fd-21b690c44b79.png)
![image](https://user-images.githubusercontent.com/31879115/112382528-06956280-8cfd-11eb-90ac-7c72ad5e1986.png)
![image](https://user-images.githubusercontent.com/31879115/112382574-12812480-8cfd-11eb-96a1-569c711669e1.png)

This is the first part of the task. I don't want to make the diffs big for easier review.

Additional polishing/next things to do:
- Highlight matched substring
- Debounce input