### PR TITLE
Fix Webpack error – resolve relative path to favicon with __dirname

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -82,7 +82,7 @@ const compiler = webpack({
   plugins: [
     ...(config.plugins ? config.plugins : []),
     new CopyWebpackPlugin({
-      patterns: [{ from: "src/favicon.png", to: "" }],
+      patterns: [{ from: path.join(__dirname, "../src/favicon.png"), to: "" }],
     }),
     new HtmlWebpackPlugin({
       template: process.argv.find((item) => item.startsWith("--template="))


### PR DESCRIPTION
## Description

I receive an annoying Webpack error in the stdout when using Reshowcase as a dependency of my project.
It tries to resolve the path to favicon relatively to my project, not relative to a library file.
Fixed it.
```
✖ ｢wdm｣: ERROR in unable to locate '/home/denis/packages/my-package/src/favicon.png' glob

webpack compiled with 1 error
ℹ ｢wdm｣: Failed to compile.
```