### PR TITLE
Move right panel out of the iframe

### DIFF
--- a/src/Configs.res
+++ b/src/Configs.res
@@ -9,7 +9,7 @@ type stringConfig = string
 
 type boolConfig = bool
 
-type demoUnit = {
+type demoUnitProps = {
   string: (string, ~options: array<(string, string)>=?, stringConfig) => string,
   int: (string, numberConfig<int>) => int,
   float: (string, numberConfig<float>) => float,

--- a/src/Entry.res
+++ b/src/Entry.res
@@ -2,14 +2,14 @@ open Belt
 
 include Configs
 
-type demo = {add: (string, Configs.demoUnit => React.element) => unit}
+type demo = {add: (string, Configs.demoUnitProps => React.element) => unit}
 
 let demos = MutableMap.String.make()
 
 let demo = (demoName, func) => {
   let demoUnits = MutableMap.String.make()
   let demo = {
-    add: (demoUnitName, demo: Configs.demoUnit => React.element) =>
+    add: (demoUnitName, demo: Configs.demoUnitProps => React.element) =>
       demoUnits->MutableMap.String.set(demoUnitName, demo),
   }
   func(demo)

--- a/src/Entry.resi
+++ b/src/Entry.resi
@@ -9,14 +9,14 @@ type stringConfig = string
 
 type boolConfig = bool
 
-type demoUnit = {
+type demoUnitProps = {
   string: (string, ~options: array<(string, string)>=?, stringConfig) => string,
   int: (string, numberConfig<int>) => int,
   float: (string, numberConfig<float>) => float,
   bool: (string, boolConfig) => bool,
 }
 
-type demo = {add: (string, Configs.demoUnit => React.element) => unit}
+type demo = {add: (string, Configs.demoUnitProps => React.element) => unit}
 
 let demo: (Belt.MutableMap.String.key, demo => unit) => unit
 

--- a/src/Entry.resi
+++ b/src/Entry.resi
@@ -9,13 +9,6 @@ type stringConfig = string
 
 type boolConfig = bool
 
-type demoUnitProps = {
-  string: (string, ~options: array<(string, string)>=?, stringConfig) => string,
-  int: (string, numberConfig<int>) => int,
-  float: (string, numberConfig<float>) => float,
-  bool: (string, boolConfig) => bool,
-}
-
 type demo = {add: (string, Configs.demoUnitProps => React.element) => unit}
 
 let demo: (Belt.MutableMap.String.key, demo => unit) => unit

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -1,28 +1,14 @@
 open Belt
 
-module ParentWindow = {
-  @val external window: Dom.window = "window"
-
-  @get
-  external getParent: Dom.window => Dom.window = "parent"
-
-  @get
-  external getDocument: Dom.window => Dom.document = "document"
-
-  @send
-  external querySelector: (Dom.document, string) => Js.Nullable.t<Dom.element> = "querySelector"
-
-  let getElementById = (id: string) =>
-    window->getParent->getDocument->querySelector("#" ++ id)->Js.Nullable.toOption
-}
-
-let rightSidebarId = "rightSidebar"
-
 module Color = ReshowcaseUi__Layout.Color
 module Gap = ReshowcaseUi__Layout.Gap
 module PaddedBox = ReshowcaseUi__Layout.PaddedBox
 module Stack = ReshowcaseUi__Layout.Stack
 module Sidebar = ReshowcaseUi__Layout.Sidebar
+module ParentWindow = ReshowcaseUi__Bindings.ParentWindow
+module URLSearchParams = ReshowcaseUi__Bindings.URLSearchParams
+
+let rightSidebarId = "rightSidebar"
 
 module Link = {
   @react.component
@@ -531,24 +517,20 @@ module App = {
       (),
     )
   }
+
   type route =
     | Unit(string, string)
     | Demo(string, string)
     | Home
-  type urlSearchParams
-  @new
-  external urlSearchParams: string => urlSearchParams = "URLSearchParams"
-  @return(nullable) @bs.send
-  external get: (urlSearchParams, string) => option<string> = "get"
 
   @react.component
   let make = (~demos) => {
     let url = ReasonReact.Router.useUrl()
-    let queryString = url.search->urlSearchParams
+    let queryString = url.search->URLSearchParams.make
     let route = switch (
-      queryString->get("iframe"),
-      queryString->get("demo"),
-      queryString->get("unit"),
+      queryString->URLSearchParams.get("iframe"),
+      queryString->URLSearchParams.get("demo"),
+      queryString->URLSearchParams.get("unit"),
     ) {
     | (Some("true"), Some(demo), Some(unit)) => Unit(demo, unit)
     | (_, Some(demo), Some(unit)) => Demo(demo, unit)

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -5,7 +5,6 @@ module Gap = ReshowcaseUi__Layout.Gap
 module PaddedBox = ReshowcaseUi__Layout.PaddedBox
 module Stack = ReshowcaseUi__Layout.Stack
 module Sidebar = ReshowcaseUi__Layout.Sidebar
-module ParentWindow = ReshowcaseUi__Bindings.ParentWindow
 module URLSearchParams = ReshowcaseUi__Bindings.URLSearchParams
 
 let rightSidebarId = "rightSidebar"
@@ -366,12 +365,14 @@ module DemoUnit = {
       )->ReactDOM.Style.unsafeAddProp("WebkitOverflowScrolling", "touch")
   }
 
+  @val external window: {..} = "window"
+
   @react.component
   let make = (~demoUnit: Configs.demoUnitProps => React.element) => {
     let (parentWindowRightSidebarElem, setParentWindowRightSidebarElem) = React.useState(() => None)
 
     React.useEffect0(() => {
-      switch ParentWindow.getElementById(rightSidebarId) {
+      switch window["parent"]["document"]["getElementById"](. rightSidebarId)->Js.Nullable.toOption {
       | None => ()
       | Some(elem) => setParentWindowRightSidebarElem(_ => Some(elem))
       }

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -476,18 +476,16 @@ module DemoUnit = {
       | None => React.null
       | Some(element) =>
         ReactDOM.createPortal(
-          <Sidebar>
-            <DemoUnitSidebar
-              strings=state.strings
-              ints=state.ints
-              floats=state.floats
-              bools=state.bools
-              onStringChange={(name, value) => dispatch(SetString(name, value))}
-              onIntChange={(name, value) => dispatch(SetInt(name, value))}
-              onFloatChange={(name, value) => dispatch(SetFloat(name, value))}
-              onBoolChange={(name, value) => dispatch(SetBool(name, value))}
-            />
-          </Sidebar>,
+          <DemoUnitSidebar
+            strings=state.strings
+            ints=state.ints
+            floats=state.floats
+            bools=state.bools
+            onStringChange={(name, value) => dispatch(SetString(name, value))}
+            onIntChange={(name, value) => dispatch(SetInt(name, value))}
+            onFloatChange={(name, value) => dispatch(SetFloat(name, value))}
+            onBoolChange={(name, value) => dispatch(SetBool(name, value))}
+          />,
           element,
         )
       }}
@@ -568,8 +566,13 @@ module App = {
         </div>
       | Demo(demoName, demoUnitName) => <>
           <DemoListSidebar demos />
-          <DemoUnitFrame demoName demoUnitName />
-          <div id=rightSidebarId key={Js.Date.now()->Belt.Float.toString} />
+          // Force rerender after switching demo to avoid stale iframe and sidebar children
+          <DemoUnitFrame
+            key={"DemoUnitFrame" ++ Js.Date.now()->Belt.Float.toString} demoName demoUnitName
+          />
+          <Sidebar
+            key={"Sidebar" ++ Js.Date.now()->Belt.Float.toString} innerContainerId=rightSidebarId
+          />
         </>
       | Home => <>
           <DemoListSidebar demos />

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -363,7 +363,7 @@ module DemoUnit = {
   }
 
   @react.component
-  let make = (~demoUnit: Configs.demoUnit => React.element) => {
+  let make = (~demoUnit: Configs.demoUnitProps => React.element) => {
     let (state, dispatch) = React.useReducer(
       (state, action) =>
         switch action {
@@ -397,7 +397,7 @@ module DemoUnit = {
         let ints = ref(Map.String.empty)
         let floats = ref(Map.String.empty)
         let bools = ref(Map.String.empty)
-        let props: Configs.demoUnit = {
+        let props: Configs.demoUnitProps = {
           string: (name, ~options=?, config) => {
             strings := strings.contents->Map.String.set(name, (config, config, options))
             config
@@ -424,7 +424,7 @@ module DemoUnit = {
         }
       },
     )
-    let props: Configs.demoUnit = {
+    let props: Configs.demoUnitProps = {
       string: (name, ~options as _=?, _config) => {
         let (_, value, _) = state.strings->Map.String.getExn(name)
         value

--- a/src/ReshowcaseUi.resi
+++ b/src/ReshowcaseUi.resi
@@ -1,6 +1,6 @@
 module App: {
   @react.component
   let make: (
-    ~demos: Belt.Map.String.t<Belt.Map.String.t<Configs.demoUnit => React.element>>,
+    ~demos: Belt.Map.String.t<Belt.Map.String.t<Configs.demoUnitProps => React.element>>,
   ) => React.element
 }

--- a/src/ReshowcaseUi__Bindings.res
+++ b/src/ReshowcaseUi__Bindings.res
@@ -1,0 +1,25 @@
+module ParentWindow = {
+  @val external window: Dom.window = "window"
+
+  @get
+  external getParent: Dom.window => Dom.window = "parent"
+
+  @get
+  external getDocument: Dom.window => Dom.document = "document"
+
+  @send
+  external querySelector: (Dom.document, string) => Js.Nullable.t<Dom.element> = "querySelector"
+
+  let getElementById = (id: string) =>
+    window->getParent->getDocument->querySelector("#" ++ id)->Js.Nullable.toOption
+}
+
+module URLSearchParams = {
+  type urlSearchParams
+
+  @new
+  external make: string => urlSearchParams = "URLSearchParams"
+
+  @return(nullable) @bs.send
+  external get: (urlSearchParams, string) => option<string> = "get"
+}

--- a/src/ReshowcaseUi__Bindings.res
+++ b/src/ReshowcaseUi__Bindings.res
@@ -1,19 +1,3 @@
-module ParentWindow = {
-  @val external window: Dom.window = "window"
-
-  @get
-  external getParent: Dom.window => Dom.window = "parent"
-
-  @get
-  external getDocument: Dom.window => Dom.document = "document"
-
-  @send
-  external querySelector: (Dom.document, string) => Js.Nullable.t<Dom.element> = "querySelector"
-
-  let getElementById = (id: string) =>
-    window->getParent->getDocument->querySelector("#" ++ id)->Js.Nullable.toOption
-}
-
 module URLSearchParams = {
   type urlSearchParams
 

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -30,8 +30,8 @@ module PaddedBox = {
   }
 
   @react.component
-  let make = (~padding: padding=Around, ~children) => {
-    <div style={Styles.getPadding(padding)}> children </div>
+  let make = (~padding: padding=Around, ~id=?, ~children) => {
+    <div ?id style={Styles.getPadding(padding)}> children </div>
   }
 }
 
@@ -60,7 +60,7 @@ module Sidebar = {
   }
 
   @react.component
-  let make = (~children) => {
-    <div style={Styles.sidebar}> <PaddedBox> children </PaddedBox> </div>
+  let make = (~innerContainerId=?, ~children=React.null) => {
+    <div style={Styles.sidebar}> <PaddedBox id=?innerContainerId> children </PaddedBox> </div>
   }
 }


### PR DESCRIPTION
## Description

Use the React portal to render the right panel out of the frame(to the main window frame).

It solves two issues:

- Some of the components are using media queries for width breakpoints and you expect that they will trigger exactly when the middle section gets the appropriate width.

- We have the components that rely on some global styles that we apply only for demos but those styles are leaking and applying to the right section with prop controls:
![image](https://user-images.githubusercontent.com/31879115/120800877-217c2280-c549-11eb-83b3-3f36122f783e.png)

Other:
- Add a module for bindings.
- Minor renaming.
 
## PR Demo
https://reshowcase-git-move-right-panel-out-of-iframe-strelkovdd.vercel.app/