### PR TITLE
Add top panel with toggle sidebar and toggle mobile viewport buttons

### DIFF
--- a/src/Entry.res
+++ b/src/Entry.res
@@ -16,10 +16,10 @@ let demo = (demoName, func) => {
   demos->MutableMap.String.set(demoName, demoUnits->MutableMap.String.toArray->Map.String.fromArray)
 }
 
-let start = () =>
+let start = (~showRightSidebar=true, ()) =>
   switch ReactDOM.querySelector("#root") {
   | Some(root) =>
     let demos = demos->MutableMap.String.toArray->Map.String.fromArray
-    ReactDOM.render(<ReshowcaseUi.App demos />, root)
+    ReactDOM.render(<ReshowcaseUi.App demos showRightSidebar />, root)
   | None => ()
   }

--- a/src/Entry.resi
+++ b/src/Entry.resi
@@ -13,4 +13,4 @@ type demo = {add: (string, Configs.demoUnitProps => React.element) => unit}
 
 let demo: (Belt.MutableMap.String.key, demo => unit) => unit
 
-let start: unit => unit
+let start: (~showRightSidebar: bool=?, unit) => unit

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -6,6 +6,7 @@ module PaddedBox = ReshowcaseUi__Layout.PaddedBox
 module Stack = ReshowcaseUi__Layout.Stack
 module Sidebar = ReshowcaseUi__Layout.Sidebar
 module URLSearchParams = ReshowcaseUi__Bindings.URLSearchParams
+module PostMessage = ReshowcaseUi__Bindings.PostMessage
 
 module TopPanel = {
   module Styles = {
@@ -571,6 +572,15 @@ module App = {
     | (_, Some(demo), Some(unit)) => Demo(demo, unit)
     | _ => Home
     }
+
+    // Key to force rerender after switching demo to avoid stale iframe and sidebar children
+    let (iframeKey, setIframeKey) = React.useState(() => Js.Date.now()->Belt.Float.toString)
+
+    React.useEffect1(() => {
+      setIframeKey(_ => Js.Date.now()->Belt.Float.toString)
+      None
+    }, [url])
+
     let (showRightSidebar, toggleShowRightSidebar) = React.useState(() => true)
     <div style=Styles.app>
       {switch route {
@@ -587,15 +597,9 @@ module App = {
           <div style=Styles.right>
             <TopPanel onRightSidebarToggle={() => toggleShowRightSidebar(_ => !showRightSidebar)} />
             <div style=Styles.demo>
-              // Force rerender after switching demo to avoid stale iframe and sidebar children
-              <DemoUnitFrame
-                key={"DemoUnitFrame" ++ Js.Date.now()->Belt.Float.toString} demoName demoUnitName
-              />
+              <DemoUnitFrame key={"DemoUnitFrame" ++ iframeKey} demoName demoUnitName />
               {showRightSidebar
-                ? <Sidebar
-                    key={"Sidebar" ++ Js.Date.now()->Belt.Float.toString}
-                    innerContainerId=rightSidebarId
-                  />
+                ? <Sidebar key={"Sidebar" ++ iframeKey} innerContainerId=rightSidebarId />
                 : React.null}
             </div>
           </div>

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -593,7 +593,7 @@ module App = {
     | Home
 
   @react.component
-  let make = (~demos) => {
+  let make = (~demos, ~showRightSidebar) => {
     let url = ReasonReact.Router.useUrl()
     let queryString = url.search->URLSearchParams.make
     let route = switch (
@@ -616,7 +616,8 @@ module App = {
       None
     }, [url])
 
-    let (showRightSidebar, toggleShowRightSidebar) = React.useState(() => true)
+    let (showRightSidebar, toggleShowRightSidebar) = React.useState(() => showRightSidebar)
+
     <div style=Styles.app>
       {switch route {
       | Unit(demoName, demoUnitName) =>

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -54,31 +54,27 @@ module TopPanel = {
   ) => {
     <div style=Styles.panel>
       <div style=Styles.middleSection>
-        <PaddedBox>
-          <PaddedBox>
-            <button
-              style=Styles.button
-              onClick={event => {
-                event->ReactEvent.Mouse.preventDefault
-                onMobileViewToggle()
-              }}>
-              {(isMobileView ? "To desktop view" : "To mobile view")->React.string}
-            </button>
-          </PaddedBox>
+        <PaddedBox gap=Md>
+          <button
+            style=Styles.button
+            onClick={event => {
+              event->ReactEvent.Mouse.preventDefault
+              onMobileViewToggle()
+            }}>
+            {(isMobileView ? "To desktop view" : "To mobile view")->React.string}
+          </button>
         </PaddedBox>
       </div>
       <div style=Styles.rightSection>
-        <PaddedBox>
-          <PaddedBox>
-            <button
-              style=Styles.button
-              onClick={event => {
-                event->ReactEvent.Mouse.preventDefault
-                onRightSidebarToggle()
-              }}>
-              {(isSidebarHidden ? "Show sidebar" : "Hide sidebar")->React.string}
-            </button>
-          </PaddedBox>
+        <PaddedBox gap=Md>
+          <button
+            style=Styles.button
+            onClick={event => {
+              event->ReactEvent.Mouse.preventDefault
+              onRightSidebarToggle()
+            }}>
+            {(isSidebarHidden ? "Show sidebar" : "Hide sidebar")->React.string}
+          </button>
         </PaddedBox>
       </div>
     </div>
@@ -211,19 +207,17 @@ module DemoListSidebar = {
 
     @react.component
     let make = (~value, ~onChange, ~onClear) =>
-      <PaddedBox padding=Around>
-        <div style=Styles.inputWrapper>
-          <input style=Styles.input placeholder="Filter" value onChange />
-          {value === "" ? React.null : <ClearButton onClear />}
-        </div>
-      </PaddedBox>
+      <div style=Styles.inputWrapper>
+        <input style=Styles.input placeholder="Filter" value onChange />
+        {value === "" ? React.null : <ClearButton onClear />}
+      </div>
   }
 
   @react.component
   let make = (~demos) => {
     let (filterValue, setFilterValue) = React.useState(() => None)
     <Sidebar>
-      <PaddedBox border=Bottom>
+      <PaddedBox gap=Md border=Bottom>
         <SearchInput
           value={filterValue->Option.getWithDefault("")}
           onChange={event => {
@@ -233,7 +227,7 @@ module DemoListSidebar = {
           onClear={() => setFilterValue(_ => None)}
         />
       </PaddedBox>
-      <PaddedBox>
+      <PaddedBox gap=Xxs>
         <Stack>
           {demos
           ->Map.String.toArray
@@ -330,92 +324,86 @@ module DemoUnitSidebar = {
     ~onBoolChange,
     _,
   ) =>
-    <PaddedBox>
-      <PaddedBox>
-        <Stack>
-          {strings
-          ->Map.String.toArray
-          ->Array.map(((propName, (_config, value, options))) =>
-            <PropBox key=propName propName>
-              {switch options {
-              | None =>
-                <input
-                  type_="text"
-                  value
-                  style=Styles.textInput
-                  onChange={event =>
-                    onStringChange(propName, (event->ReactEvent.Form.target)["value"])}
-                />
-              | Some(options) =>
-                <select
-                  style=Styles.select
-                  onChange={event => {
-                    let value = (event->ReactEvent.Form.target)["value"]
-                    onStringChange(propName, value)
-                  }}>
-                  {options
-                  ->Array.map(((key, optionValue)) => {
-                    <option key selected={value == optionValue} value={optionValue}>
-                      {key->React.string}
-                    </option>
-                  })
-                  ->React.array}
-                </select>
-              }}
-            </PropBox>
-          )
-          ->React.array}
-          {ints
-          ->Map.String.toArray
-          ->Array.map(((propName, ({min, max}, value))) =>
-            <PropBox key=propName propName>
+    <PaddedBox gap=Md>
+      <Stack>
+        {strings
+        ->Map.String.toArray
+        ->Array.map(((propName, (_config, value, options))) =>
+          <PropBox key=propName propName>
+            {switch options {
+            | None =>
               <input
-                type_="number"
-                min=j`$min`
-                max=j`$max`
-                value=j`$value`
+                type_="text"
+                value
                 style=Styles.textInput
                 onChange={event =>
-                  onIntChange(propName, (event->ReactEvent.Form.target)["value"]->int_of_string)}
+                  onStringChange(propName, (event->ReactEvent.Form.target)["value"])}
               />
-            </PropBox>
-          )
-          ->React.array}
-          {floats
-          ->Map.String.toArray
-          ->Array.map(((propName, ({min, max}, value))) =>
-            <PropBox key=propName propName>
-              <input
-                type_="number"
-                min=j`$min`
-                max=j`$max`
-                value=j`$value`
-                style=Styles.textInput
-                onChange={event =>
-                  onFloatChange(
-                    propName,
-                    (event->ReactEvent.Form.target)["value"]->float_of_string,
-                  )}
-              />
-            </PropBox>
-          )
-          ->React.array}
-          {bools
-          ->Map.String.toArray
-          ->Array.map(((propName, (_config, checked))) =>
-            <PropBox key=propName propName>
-              <input
-                type_="checkbox"
-                checked
-                style=Styles.checkbox
-                onChange={event =>
-                  onBoolChange(propName, (event->ReactEvent.Form.target)["checked"])}
-              />
-            </PropBox>
-          )
-          ->React.array}
-        </Stack>
-      </PaddedBox>
+            | Some(options) =>
+              <select
+                style=Styles.select
+                onChange={event => {
+                  let value = (event->ReactEvent.Form.target)["value"]
+                  onStringChange(propName, value)
+                }}>
+                {options
+                ->Array.map(((key, optionValue)) => {
+                  <option key selected={value == optionValue} value={optionValue}>
+                    {key->React.string}
+                  </option>
+                })
+                ->React.array}
+              </select>
+            }}
+          </PropBox>
+        )
+        ->React.array}
+        {ints
+        ->Map.String.toArray
+        ->Array.map(((propName, ({min, max}, value))) =>
+          <PropBox key=propName propName>
+            <input
+              type_="number"
+              min=j`$min`
+              max=j`$max`
+              value=j`$value`
+              style=Styles.textInput
+              onChange={event =>
+                onIntChange(propName, (event->ReactEvent.Form.target)["value"]->int_of_string)}
+            />
+          </PropBox>
+        )
+        ->React.array}
+        {floats
+        ->Map.String.toArray
+        ->Array.map(((propName, ({min, max}, value))) =>
+          <PropBox key=propName propName>
+            <input
+              type_="number"
+              min=j`$min`
+              max=j`$max`
+              value=j`$value`
+              style=Styles.textInput
+              onChange={event =>
+                onFloatChange(propName, (event->ReactEvent.Form.target)["value"]->float_of_string)}
+            />
+          </PropBox>
+        )
+        ->React.array}
+        {bools
+        ->Map.String.toArray
+        ->Array.map(((propName, (_config, checked))) =>
+          <PropBox key=propName propName>
+            <input
+              type_="checkbox"
+              checked
+              style=Styles.checkbox
+              onChange={event => onBoolChange(propName, (event->ReactEvent.Form.target)["checked"])}
+            />
+          </PropBox>
+        )
+        ->React.array}
+      </Stack>
     </PaddedBox>
 }
 

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -399,16 +399,17 @@ module DemoUnit = {
 
   @val external window: {..} = "window"
 
+  let getRightSidebarElement = (): option<Dom.element> =>
+    window["parent"]["document"]["getElementById"](. rightSidebarId)->Js.Nullable.toOption
+
   @react.component
   let make = (~demoUnit: Configs.demoUnitProps => React.element) => {
     let (parentWindowRightSidebarElem, setParentWindowRightSidebarElem) = React.useState(() => None)
 
     React.useEffect0(() => {
-      switch window["parent"]["document"]["getElementById"](.
-        rightSidebarId,
-      )->Js.Nullable.toOption {
-      | None => ()
+      switch getRightSidebarElement() {
       | Some(elem) => setParentWindowRightSidebarElem(_ => Some(elem))
+      | None => ()
       }
       None
     })
@@ -418,8 +419,12 @@ module DemoUnit = {
         if window["parent"] === event["source"] {
           let message: string = event["data"]
           switch message->Message.fromStringOpt {
-          | Some(RightSidebarDisplayed) => Js.log("RightSidebarDisplayed")
-          | None => Js.log("Unknown message")
+          | Some(RightSidebarDisplayed) =>
+            switch getRightSidebarElement() {
+            | Some(elem) => setParentWindowRightSidebarElem(_ => Some(elem))
+            | None => ()
+            }
+          | None => Js.Console.error("Unexpected message received")
           }
         }
       })

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -8,7 +8,6 @@ module Stack = ReshowcaseUi__Layout.Stack
 module Sidebar = ReshowcaseUi__Layout.Sidebar
 module URLSearchParams = ReshowcaseUi__Bindings.URLSearchParams
 module Window = ReshowcaseUi__Bindings.Window
-module Message = ReshowcaseUi__Bindings.Message
 
 module TopPanel = {
   module Styles = {
@@ -216,7 +215,7 @@ module DemoListSidebar = {
   @react.component
   let make = (~demos) => {
     let (filterValue, setFilterValue) = React.useState(() => None)
-    <Sidebar>
+    <Sidebar fullHeight=true>
       <PaddedBox gap=Md border=Bottom>
         <SearchInput
           value={filterValue->Option.getWithDefault("")}
@@ -431,7 +430,6 @@ module DemoUnit = {
     )
     let contents =
       ReactDOM.Style.make(
-        ~height="100vh",
         ~flexGrow="1",
         ~overflowY="auto",
         ~display="flex",
@@ -442,10 +440,8 @@ module DemoUnit = {
       )->ReactDOM.Style.unsafeAddProp("WebkitOverflowScrolling", "touch")
   }
 
-  @val external window: {..} = "window"
-
   let getRightSidebarElement = (): option<Dom.element> =>
-    window["parent"]["document"]["getElementById"](. rightSidebarId)->Js.Nullable.toOption
+    Window.window["parent"]["document"]["getElementById"](. rightSidebarId)->Js.Nullable.toOption
 
   @react.component
   let make = (~demoUnit: Configs.demoUnitProps => React.element) => {
@@ -461,9 +457,9 @@ module DemoUnit = {
 
     React.useEffect0(() => {
       Window.addMessageListener(event => {
-        if window["parent"] === event["source"] {
+        if Window.window["parent"] === event["source"] {
           let message: string = event["data"]
-          switch message->Message.fromStringOpt {
+          switch message->Window.Message.fromStringOpt {
           | Some(RightSidebarDisplayed) =>
             switch getRightSidebarElement() {
             | Some(elem) => setParentWindowRightSidebarElem(_ => Some(elem))
@@ -554,7 +550,7 @@ module DemoUnit = {
         value
       },
     }
-    <div style=Styles.container>
+    <div name="DemoUnit" style=Styles.container>
       <div style=Styles.contents> {demoUnit(props)} </div>
       {switch parentWindowRightSidebarElem {
       | None => React.null

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -554,7 +554,7 @@ module DemoUnitFrame = {
       | (Some(demo), Some(unit)) => j`?iframe=true&demo=$demo&unit=$unit`
       | _ => "?iframe=true"
       }}
-      style={ReactDOM.Style.make(~height="100vh", ~width="100%", ~border="none", ())}
+      style={ReactDOM.Style.make(~height="100%", ~width="100%", ~border="none", ())}
     />
 }
 
@@ -584,7 +584,7 @@ module App = {
       (),
     )
     let right = ReactDOM.Style.make(~display="flex", ~flexDirection="column", ~width="100%", ())
-    let demo = ReactDOM.Style.make(~display="flex", ~flexDirection="row", ())
+    let demo = ReactDOM.Style.make(~display="flex", ~flex="1", ~flexDirection="row", ())
   }
 
   type route =
@@ -618,7 +618,7 @@ module App = {
 
     let (showRightSidebar, toggleShowRightSidebar) = React.useState(() => showRightSidebar)
 
-    <div style=Styles.app>
+    <div name="App" style=Styles.app>
       {switch route {
       | Unit(demoName, demoUnitName) =>
         <div style=Styles.main>
@@ -630,7 +630,7 @@ module App = {
         </div>
       | Demo(demoName, demoUnitName) => <>
           <DemoListSidebar demos />
-          <div style=Styles.right>
+          <div name="Content" style=Styles.right>
             <TopPanel
               isSidebarHidden={!showRightSidebar}
               onRightSidebarToggle={() => {
@@ -644,7 +644,7 @@ module App = {
                 }
               }}
             />
-            <div style=Styles.demo>
+            <div name="Demo" style=Styles.demo>
               <DemoUnitFrame
                 key={"DemoUnitFrame" ++ iframeKey}
                 onLoad={iframeWindow => setLoadedIframeWindow(_ => Some(iframeWindow))}

--- a/src/ReshowcaseUi.resi
+++ b/src/ReshowcaseUi.resi
@@ -2,5 +2,6 @@ module App: {
   @react.component
   let make: (
     ~demos: Belt.Map.String.t<Belt.Map.String.t<Configs.demoUnitProps => React.element>>,
+    ~showRightSidebar: bool,
   ) => React.element
 }

--- a/src/ReshowcaseUi__Bindings.res
+++ b/src/ReshowcaseUi__Bindings.res
@@ -8,26 +8,27 @@ module URLSearchParams = {
   external get: (urlSearchParams, string) => option<string> = "get"
 }
 
-module Message = {
-  type t = RightSidebarDisplayed
-
-  let toString = (message: t) =>
-    switch message {
-    | RightSidebarDisplayed => "RightSidebarDisplayed"
-    }
-
-  let fromStringOpt = (string): option<t> =>
-    switch string {
-    | "RightSidebarDisplayed" => Some(RightSidebarDisplayed)
-    | _ => None
-    }
-}
-
 module Window = {
+  module Message = {
+    type t = RightSidebarDisplayed
+
+    let toString = (message: t) =>
+      switch message {
+      | RightSidebarDisplayed => "RightSidebarDisplayed"
+      }
+
+    let fromStringOpt = (string): option<t> =>
+      switch string {
+      | "RightSidebarDisplayed" => Some(RightSidebarDisplayed)
+      | _ => None
+      }
+  }
+
   @val external window: {..} = "window"
 
   let addMessageListener = (func: Js.t<'a> => unit): unit =>
     window["addEventListener"](. "message", func, false)
 
-  let postMessage = (w, message: Message.t) => w["postMessage"](. message->Message.toString, "*")
+  let postMessage = (window, message: Message.t) =>
+    window["postMessage"](. message->Message.toString, "*")
 }

--- a/src/ReshowcaseUi__Bindings.res
+++ b/src/ReshowcaseUi__Bindings.res
@@ -7,3 +7,27 @@ module URLSearchParams = {
   @return(nullable) @bs.send
   external get: (urlSearchParams, string) => option<string> = "get"
 }
+
+module Message = {
+  type t = RightSidebarDisplayed
+
+  let toString = (message: t) =>
+    switch message {
+    | RightSidebarDisplayed => "RightSidebarDisplayed"
+    }
+
+  let fromStringOpt = (string): option<t> =>
+    switch string {
+    | "RightSidebarDisplayed" => Some(RightSidebarDisplayed)
+    | _ => None
+    }
+}
+
+module Window = {
+  @val external window: {..} = "window"
+
+  let addMessageListener = (func: Js.t<'a> => unit): unit =>
+    window["addEventListener"](. "message", func, false)
+
+  let postMessage = (w, message: Message.t) => w["postMessage"](. message->Message.toString, "*")
+}

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -9,8 +9,18 @@ module Color = {
 }
 
 module Gap = {
+  let xxs = "3px"
   let xs = "7px"
   let md = "10px"
+
+  type t = Xxs | Xs | Md
+
+  let getGap = (gap: t) =>
+    switch gap {
+    | Xxs => xxs
+    | Xs => xs
+    | Md => md
+    }
 }
 
 module Border = {
@@ -23,16 +33,18 @@ module PaddedBox = {
   type border = None | Bottom
 
   module Styles = {
-    let around = ReactDOM.Style.make(~padding=Gap.xs, ())
-    let leftRight = ReactDOM.Style.make(~padding=`0 ${Gap.xs}`, ())
-    let topLeftRight = ReactDOM.Style.make(~padding=`${Gap.xs} ${Gap.xs} 0`, ())
+    let around = gapValue => ReactDOM.Style.make(~padding=gapValue, ())
+    let leftRight = gapValue => ReactDOM.Style.make(~padding=`0 ${gapValue}`, ())
+    let topLeftRight = gapValue => ReactDOM.Style.make(~padding=`${gapValue} ${gapValue} 0`, ())
 
-    let getPadding = (padding: padding) =>
+    let getPadding = (padding: padding, gap: Gap.t) => {
+      let gapValue = Gap.getGap(gap)
       switch padding {
-      | Around => around
-      | LeftRight => leftRight
-      | TopLeftRight => topLeftRight
+      | Around => around(gapValue)
+      | LeftRight => leftRight(gapValue)
+      | TopLeftRight => topLeftRight(gapValue)
       }
+    }
 
     let getBorder = (border: border) => {
       switch border {
@@ -41,16 +53,16 @@ module PaddedBox = {
       }
     }
 
-    let make = (~padding, ~border) => {
-      let paddingStyles = getPadding(padding)
+    let make = (~padding, ~gap, ~border) => {
+      let paddingStyles = getPadding(padding, gap)
       let borderStyles = getBorder(border)
       ReactDOM.Style.combine(paddingStyles, borderStyles)
     }
   }
 
   @react.component
-  let make = (~padding: padding=Around, ~border: border=None, ~id=?, ~children) => {
-    <div name="PaddedBox" ?id style={Styles.make(~padding, ~border)}> children </div>
+  let make = (~gap: Gap.t=Xs, ~padding: padding=Around, ~border: border=None, ~id=?, ~children) => {
+    <div name="PaddedBox" ?id style={Styles.make(~padding, ~border, ~gap)}> children </div>
   }
 }
 

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -68,7 +68,6 @@ module Sidebar = {
       ReactDOM.Style.make(
         ~minWidth="230px",
         ~width="230px",
-        ~height="100vh",
         ~overflowY="auto",
         ~backgroundColor=Color.lightGray,
         (),
@@ -77,6 +76,6 @@ module Sidebar = {
 
   @react.component
   let make = (~innerContainerId=?, ~children=React.null) => {
-    <div id=?innerContainerId style={Styles.sidebar}> children </div>
+    <div name="Sidebar" id=?innerContainerId style={Styles.sidebar}> children </div>
   }
 }

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -16,6 +16,8 @@ module Gap = {
 module PaddedBox = {
   type padding = Around | LeftRight | TopLeftRight
 
+  type border = None | Bottom
+
   module Styles = {
     let around = ReactDOM.Style.make(~padding=Gap.xs, ())
     let leftRight = ReactDOM.Style.make(~padding=`0 ${Gap.xs}`, ())
@@ -27,11 +29,25 @@ module PaddedBox = {
       | LeftRight => leftRight
       | TopLeftRight => topLeftRight
       }
+
+    let getBorder = (border: border) => {
+      let borderValue = `1px solid ${Color.midGray}`
+      switch border {
+      | None => ReactDOM.Style.make()
+      | Bottom => ReactDOM.Style.make(~borderBottom=borderValue, ())
+      }
+    }
+
+    let make = (~padding, ~border) => {
+      let paddingStyles = getPadding(padding)
+      let borderStyles = getBorder(border)
+      ReactDOM.Style.combine(paddingStyles, borderStyles)
+    }
   }
 
   @react.component
-  let make = (~padding: padding=Around, ~id=?, ~children) => {
-    <div ?id style={Styles.getPadding(padding)}> children </div>
+  let make = (~padding: padding=Around, ~border: border=None, ~id=?, ~children) => {
+    <div name="PaddedBox" ?id style={Styles.make(~padding, ~border)}> children </div>
   }
 }
 
@@ -61,6 +77,6 @@ module Sidebar = {
 
   @react.component
   let make = (~innerContainerId=?, ~children=React.null) => {
-    <div style={Styles.sidebar}> <PaddedBox id=?innerContainerId> children </PaddedBox> </div>
+    <div id=?innerContainerId style={Styles.sidebar}> children </div>
   }
 }

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -73,7 +73,7 @@ module Stack = {
 
   @react.component
   let make = (~children) => {
-    <div style={Styles.stack}> children </div>
+    <div name="Stack" style={Styles.stack}> children </div>
   }
 }
 
@@ -81,10 +81,11 @@ module Sidebar = {
   module Styles = {
     let width = "230px"
 
-    let sidebar =
+    let sidebar = (~fullHeight) =>
       ReactDOM.Style.make(
         ~minWidth=width,
         ~width,
+        ~height={fullHeight ? "100vh" : "auto"},
         ~overflowY="auto",
         ~backgroundColor=Color.lightGray,
         (),
@@ -92,7 +93,7 @@ module Sidebar = {
   }
 
   @react.component
-  let make = (~innerContainerId=?, ~children=React.null) => {
-    <div name="Sidebar" id=?innerContainerId style={Styles.sidebar}> children </div>
+  let make = (~innerContainerId=?, ~fullHeight=false, ~children=React.null) => {
+    <div name="Sidebar" id=?innerContainerId style={Styles.sidebar(~fullHeight)}> children </div>
   }
 }

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -13,6 +13,10 @@ module Gap = {
   let md = "10px"
 }
 
+module Border = {
+  let default = `1px solid ${Color.midGray}`
+}
+
 module PaddedBox = {
   type padding = Around | LeftRight | TopLeftRight
 
@@ -31,10 +35,9 @@ module PaddedBox = {
       }
 
     let getBorder = (border: border) => {
-      let borderValue = `1px solid ${Color.midGray}`
       switch border {
       | None => ReactDOM.Style.make()
-      | Bottom => ReactDOM.Style.make(~borderBottom=borderValue, ())
+      | Bottom => ReactDOM.Style.make(~borderBottom=Border.default, ())
       }
     }
 
@@ -64,10 +67,12 @@ module Stack = {
 
 module Sidebar = {
   module Styles = {
+    let width = "230px"
+
     let sidebar =
       ReactDOM.Style.make(
-        ~minWidth="230px",
-        ~width="230px",
+        ~minWidth=width,
+        ~width,
         ~overflowY="auto",
         ~backgroundColor=Color.lightGray,
         (),


### PR DESCRIPTION
## Description

Add top panel with toggle sidebar and toggle mobile viewport buttons:

![image](https://user-images.githubusercontent.com/31879115/123136877-189db300-d45c-11eb-973a-8c7f4274e0c8.png)

Most of the time we are not using props API and the right panel is empty most of the time. It takes too much space.

- Allow hide/show right panel and allow to pass a prop to show or hide it by default.
- Add a button to change demo viewport size to mobile.

The communication between windows setup via `window.postMessage` to keep props state and avoid full reloading of the iframe after props panel toggling.

## Preview

- https://reshowcase-git-add-top-panel-strelkovdd.vercel.app/