### PR TITLE
Raise warnings to errors, remove esy.json

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -22,5 +22,9 @@
   "suffix": ".bs.js",
   "namespace": true,
   "bs-dependencies": ["reason-react"],
-  "refmt": 3
+  "warnings": {
+    "number": "+A-4-9-20",
+    "error": "+A"
+  },
+  "refmt": 3,
 }

--- a/esy.json
+++ b/esy.json
@@ -1,9 +1,0 @@
-{
-  "dependencies": {
-    "@opam/dune": "2.7.1",
-    "@opam/ocaml-lsp-server": "*",
-    "@opam/ocamlfind-secondary": "*",
-    "@opam/reason": "*",
-    "ocaml": "4.6.x"
-  }
-}

--- a/src/Entry.res
+++ b/src/Entry.res
@@ -16,10 +16,10 @@ let demo = (demoName, func) => {
   demos->MutableMap.String.set(demoName, demoUnits->MutableMap.String.toArray->Map.String.fromArray)
 }
 
-let start = (~showRightSidebar=true, ()) =>
+let start = () =>
   switch ReactDOM.querySelector("#root") {
   | Some(root) =>
     let demos = demos->MutableMap.String.toArray->Map.String.fromArray
-    ReactDOM.render(<ReshowcaseUi.App demos showRightSidebar />, root)
+    ReactDOM.render(<ReshowcaseUi.App demos />, root)
   | None => ()
   }

--- a/src/Entry.resi
+++ b/src/Entry.resi
@@ -13,4 +13,4 @@ type demo = {add: (string, Configs.demoUnitProps => React.element) => unit}
 
 let demo: (Belt.MutableMap.String.key, demo => unit) => unit
 
-let start: (~showRightSidebar: bool=?, unit) => unit
+let start: unit => unit

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -744,7 +744,7 @@ module App = {
     | Home
 
   @react.component
-  let make = (~demos, ~showRightSidebar) => {
+  let make = (~demos) => {
     let url = ReasonReact.Router.useUrl()
     let queryString = url.search->URLSearchParams.make
     let route = switch (

--- a/src/ReshowcaseUi.resi
+++ b/src/ReshowcaseUi.resi
@@ -1,7 +1,6 @@
 module App: {
   @react.component
   let make: (
-    ~demos: Belt.Map.String.t<Belt.Map.String.t<Configs.demoUnitProps => React.element>>,
-    ~showRightSidebar: bool,
+    ~demos: Belt.Map.String.t<Belt.Map.String.t<Configs.demoUnitProps => React.element>>
   ) => React.element
 }


### PR DESCRIPTION
## Description

After switching to a Local Storage to keep the sidebar setting, the prop `showRightSidebar` remained unused in a code.
I am proposing to raise all warnings to compile errors for more clean code.

Also, removed `esy.json`. Ocaml platform extension is no longer needed after migration to rescript.

