### PR TITLE
Add a component to highlight substring of filtered demo name/demo unit name

### DIFF
--- a/src/Demos.res
+++ b/src/Demos.res
@@ -1,6 +1,5 @@
 open Belt
-module BeltArray = Array
-module Array = Js.Array2
+
 module URLSearchParams = ReshowcaseUi__Bindings.URLSearchParams
 
 type t = Js.Dict.t<Entity.t>

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -7,6 +7,7 @@ module PaddedBox = ReshowcaseUi__Layout.PaddedBox
 module Stack = ReshowcaseUi__Layout.Stack
 module Sidebar = ReshowcaseUi__Layout.Sidebar
 module Icon = ReshowcaseUi__Layout.Icon
+module HighlightSubstring = ReshowcaseUi__Layout.HighlightSubstring
 module URLSearchParams = ReshowcaseUi__Bindings.URLSearchParams
 module Window = ReshowcaseUi__Bindings.Window
 module Array = Js.Array2
@@ -134,7 +135,7 @@ let rightSidebarId = "rightSidebar"
 
 module Link = {
   @react.component
-  let make = (~href, ~text, ~style=?, ~activeStyle=?) => {
+  let make = (~href, ~text: React.element, ~style=?, ~activeStyle=?) => {
     let url = ReasonReact.Router.useUrl()
     let path = String.concat("/", url.path)
     let isActive = (path ++ ("?" ++ url.search))->Js.String2.endsWith(href)
@@ -154,7 +155,7 @@ module Link = {
       | (_, Some(activeStyle), true) => Some(activeStyle)
       | _ => None
       }}>
-      {text->React.string}
+      text
     </a>
   }
 }
@@ -243,7 +244,7 @@ module DemoListSidebar = {
             style=Styles.link
             activeStyle=Styles.activeLink
             href={"?demo=" ++ entityName->Js.Global.encodeURIComponent ++ categoryQuery}
-            text=entityName
+            text=<HighlightSubstring text=entityName substring />
           />
         } else {
           React.null
@@ -252,7 +253,7 @@ module DemoListSidebar = {
         if entityNameHasSubstring || Demos.hasNestedEntityWithSubstring(demos, substring) {
           let levelStr = Int.toString(level)
           <PaddedBox key={entityName} padding=LeftRight>
-            <div style=Styles.categoryName> {entityName->React.string} </div>
+            <div style=Styles.categoryName> <HighlightSubstring text=entityName substring />  </div>
             {renderMenu(
               ~filterValue,
               ~nesting=(

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -5,6 +5,7 @@ module Color = {
   let darkGray = "#42484d"
   let black40a = "rgba(0, 0, 0, 0.4)"
   let blue = "#0091ff"
+  let orange = "#ffae4b"
   let transparent = "transparent"
 }
 
@@ -140,4 +141,33 @@ module Icon = {
         d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
       />
     </svg>
+}
+
+module HighlightSubstring = {
+  @react.component
+  let make = (~text, ~substring) =>
+    switch substring {
+    | "" => text->React.string
+    | _ => {
+        let indexFrom = Js.String2.indexOf(
+          Js.String2.toLowerCase(text),
+          Js.String2.toLowerCase(substring),
+        )
+        switch indexFrom {
+        | -1 => text->React.string
+        | _ =>
+          let indexTo = indexFrom + Js.String2.length(substring)
+          let leftPart = Js.String2.slice(text, ~from=0, ~to_=indexFrom)
+          let markedPart = Js.String2.slice(text, ~from=indexFrom, ~to_=indexTo)
+          let rightPart = Js.String2.slice(text, ~from=indexTo, ~to_=Js.String2.length(text))
+          <>
+            {leftPart->React.string}
+            <mark style={ReactDOM.Style.make(~backgroundColor=Color.orange, ())}>
+              {markedPart->React.string}
+            </mark>
+            {rightPart->React.string}
+          </>
+        }
+      }
+    }
 }


### PR DESCRIPTION
## Description
Add a component to highlight substring of filtered demo name or demo unit name.

![Screenshot 2021-08-08 at 22 53 57](https://user-images.githubusercontent.com/31879115/128644102-ae8cbe98-9262-4396-90dc-cbec3a81868a.png)

## Demo
https://reshowcase-git-hightlight-substring-strelkovdd.vercel.app/