### PR TITLE
Allow overlaying to webpack dev server config

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -127,6 +127,7 @@ if (isBuild) {
       index: "/index.html",
     },
     stats: "errors-only",
+    ...(config.devServer || {})
   });
 
   server.listen(port, "0.0.0.0");


### PR DESCRIPTION
## Description

Add possibility to overlay to Webpack Dev Server config.
The main use-case (for me) is to set up [proxying](https://webpack.js.org/configuration/dev-server/#devserverproxy).
