### PR TITLE
Fix category keys filtering in a query string

### DIFF
--- a/src/Demos.res
+++ b/src/Demos.res
@@ -32,7 +32,7 @@ let findDemo = (urlSearchParams: URLSearchParams.t, demoName, demos: t) => {
     urlSearchParams
     ->URLSearchParams.toArray()
     ->List.fromArray
-    ->List.keep(((key, _value)) => key != "demo" && key != "iframe")
+    ->List.keep(((key, _value)) => key->Js.String2.startsWith("category"))
     ->List.sort(((categoryNum1, _), (categoryNum2, _)) =>
       String.compare(categoryNum1, categoryNum2)
     )


### PR DESCRIPTION
## Description

Fix filtering categories in a query string to avoid handling unrelated query params as categories.

We have a filter component that adds a param to a query string. This param is incorrectly handled as a category which results in a broken story with `Demo not found` after param added.

## Preview
https://reshowcase-4mdr76yux-strelkovdd.vercel.app/?demo=H1&category1=Headings&category0=Typography&hello=world



