### PR TITLE
Allow listening on socket

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -130,7 +130,10 @@ if (isBuild) {
     ...(config.devServer || {})
   });
 
-  server.listen(port, "0.0.0.0");
-
-  child_process.exec("open http://localhost:" + port, () => {});
+  if (config.devServer && config.devServer.socket) {
+    server.listen(config.devServer.socket);
+  } else {
+    server.listen(port, "0.0.0.0");
+    child_process.exec("open http://localhost:" + port, () => {});
+  }
 }


### PR DESCRIPTION
Reshowcase always starts webpack dev server on a port, even if socket is provided in the configuration.

This PR introduces a check: if socket is defined, start listening on it, if not — use port. 