### PR TITLE
Add collapsible categories

### DIFF
--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -275,7 +275,8 @@ module DemoListSidebar = {
                 title={<div style=Styles.categoryName>
                   <HighlightSubstring text=entityName substring />
                 </div>}
-                isDefaultOpen={isCategoryInQuery || !isCategoriesCollapsed}>
+                isDefaultOpen={isCategoryInQuery || !isCategoriesCollapsed}
+                isForceOpen={substring != ""}>
                 {renderMenu(
                   ~parentCategoryHasSubstring=entityNameHasSubstring || parentCategoryHasSubstring,
                   ~filterValue,

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -179,7 +179,7 @@ module DemoListSidebar = {
       (),
     )
 
-    let activeLink = ReactDOM.Style.make(~backgroundColor=Color.blue, ~color=Color.white, ())
+    let activeLink = ReactDOM.Style.make(~backgroundColor=Color.midGray, ())
   }
 
   module SearchInput = {

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -246,7 +246,13 @@ module DemoListSidebar = {
     ~filterValue,
     demos: Demos.t,
   ) => {
-    let rec renderMenu = (~filterValue, ~nestingLevel, ~categoryQuery, demos: Demos.t) => {
+    let rec renderMenu = (
+      ~parentCategoryHasSubstring: bool,
+      ~filterValue,
+      ~nestingLevel,
+      ~categoryQuery,
+      demos: Demos.t,
+    ) => {
       let demos = demos->Js.Dict.entries
       let substring = filterValue->Option.mapWithDefault("", Js.String2.toLowerCase)
 
@@ -256,7 +262,7 @@ module DemoListSidebar = {
           entityName->Js.String2.toLowerCase->Js.String2.includes(substring)
         switch entity {
         | Demo(_) =>
-          if entityNameHasSubstring {
+          if entityNameHasSubstring || parentCategoryHasSubstring {
             <Link
               key={entityName}
               style=Styles.link
@@ -268,7 +274,11 @@ module DemoListSidebar = {
             React.null
           }
         | Category(demos) =>
-          if entityNameHasSubstring || Demos.hasNestedEntityWithSubstring(demos, substring) {
+          if (
+            entityNameHasSubstring ||
+            Demos.hasNestedEntityWithSubstring(demos, substring) ||
+            parentCategoryHasSubstring
+          ) {
             let levelStr = Int.toString(nestingLevel)
             let categoryQueryKey = `category${levelStr}`
             let isCategoryInQuery = switch urlSearchParams->URLSearchParams.get(categoryQueryKey) {
@@ -283,6 +293,7 @@ module DemoListSidebar = {
                 </div>}
                 isDefaultOpen={isCategoryInQuery || !isCategoriesCollapsed}>
                 {renderMenu(
+                  ~parentCategoryHasSubstring=entityNameHasSubstring || parentCategoryHasSubstring,
                   ~filterValue,
                   ~nestingLevel=nestingLevel + 1,
                   ~categoryQuery=`&category${levelStr}=` ++
@@ -300,7 +311,13 @@ module DemoListSidebar = {
       ->React.array
     }
 
-    renderMenu(~filterValue, ~nestingLevel=0, ~categoryQuery="", (demos: Demos.t))
+    renderMenu(
+      ~parentCategoryHasSubstring=false,
+      ~filterValue,
+      ~nestingLevel=0,
+      ~categoryQuery="",
+      (demos: Demos.t),
+    )
   }
 
   @react.component

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -320,14 +320,12 @@ module DemoListSidebar = {
     )
   }
 
-
-
   @react.component
   let make = (
     ~urlSearchParams: URLSearchParams.t,
     ~demos: Demos.t,
     ~isCategoriesCollapsed: bool,
-    ~onToggleCollapseCategories: unit => unit,
+    ~onToggleCollapsedCategories: unit => unit,
   ) => {
     let (filterValue, setFilterValue) = React.useState(() => None)
     <Sidebar fullHeight=true>
@@ -354,7 +352,7 @@ module DemoListSidebar = {
             title={"Toggle default collapsed categories"}
             onClick={event => {
               event->ReactEvent.Mouse.preventDefault
-              onToggleCollapseCategories()
+              onToggleCollapsedCategories()
             }}>
             {isCategoriesCollapsed ? Icon.categoryCollapsed : Icon.categoryExpanded}
           </button>
@@ -827,12 +825,12 @@ module App = {
 
     let (isCategoriesCollapsed, toggleIsCategoriesCollapsed) = React.useState(() => {
       switch LocalStorage.localStorage->LocalStorage.getItem("isCategoriesCollapsed") {
-      | Some("false") => false
-      | _ => true
+      | Some("true") => true
+      | _ => false
       }
     })
 
-    let onToggleCollapseCategories = () => {
+    let onToggleCollapsedCategories = () => {
       toggleIsCategoriesCollapsed(_ => !isCategoriesCollapsed)
       LocalStorage.localStorage->LocalStorage.setItem(
         "isCategoriesCollapsed",
@@ -851,7 +849,9 @@ module App = {
           </div>
         }
       | Demo(queryString) => <>
-          <DemoListSidebar demos urlSearchParams isCategoriesCollapsed onToggleCollapseCategories />
+          <DemoListSidebar
+            demos urlSearchParams isCategoriesCollapsed onToggleCollapsedCategories
+          />
           <div name="Content" style=Styles.right>
             <TopPanel
               isSidebarHidden={!showRightSidebar}
@@ -883,7 +883,9 @@ module App = {
           </div>
         </>
       | Home => <>
-          <DemoListSidebar demos urlSearchParams isCategoriesCollapsed onToggleCollapseCategories />
+          <DemoListSidebar
+            demos urlSearchParams isCategoriesCollapsed onToggleCollapsedCategories
+          />
           <div style=Styles.empty>
             <div style=Styles.emptyText> {"Pick a demo"->React.string} </div>
           </div>

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -3,6 +3,8 @@ open Belt
 module Color = ReshowcaseUi__Layout.Color
 module Gap = ReshowcaseUi__Layout.Gap
 module Border = ReshowcaseUi__Layout.Border
+module BorderRadius = ReshowcaseUi__Layout.BorderRadius
+module FontSize = ReshowcaseUi__Layout.FontSize
 module PaddedBox = ReshowcaseUi__Layout.PaddedBox
 module Stack = ReshowcaseUi__Layout.Stack
 module Sidebar = ReshowcaseUi__Layout.Sidebar
@@ -32,7 +34,7 @@ module TopPanel = {
       ~display="flex",
       ~flexDirection="row",
       ~alignItems="stretch",
-      ~borderRadius="7px",
+      ~borderRadius=BorderRadius.default,
       (),
     )
 
@@ -40,7 +42,7 @@ module TopPanel = {
       ~height="32px",
       ~width="48px",
       ~cursor="pointer",
-      ~fontSize="14px",
+      ~fontSize=FontSize.sm,
       ~backgroundColor=Color.lightGray,
       ~color=Color.darkGray,
       ~border="none",
@@ -159,16 +161,24 @@ module Link = {
 
 module DemoListSidebar = {
   module Styles = {
-    let categoryName = ReactDOM.Style.make(~fontWeight="500", ~padding=`${Gap.xs} ${Gap.xxs}`, ())
+    let categoryName = ReactDOM.Style.make(
+      ~padding=`${Gap.xs} ${Gap.xxs}`,
+      ~fontSize=FontSize.md,
+      ~fontWeight="500",
+      (),
+    )
+
     let link = ReactDOM.Style.make(
       ~textDecoration="none",
       ~color=Color.blue,
       ~display="block",
       ~padding=`${Gap.xs} ${Gap.md}`,
-      ~borderRadius="7px",
+      ~borderRadius=BorderRadius.default,
+      ~fontSize=FontSize.md,
       ~fontWeight="500",
       (),
     )
+
     let activeLink = ReactDOM.Style.make(~backgroundColor=Color.blue, ~color=Color.white, ())
   }
 
@@ -193,7 +203,7 @@ module DemoListSidebar = {
         ~display="flex",
         ~alignItems="center",
         ~backgroundColor=Color.midGray,
-        ~borderRadius="7px",
+        ~borderRadius=BorderRadius.default,
         (),
       )
 
@@ -201,11 +211,13 @@ module DemoListSidebar = {
         ~padding=`${Gap.xs} ${Gap.md}`,
         ~width="100%",
         ~margin="0",
+        ~height="32px",
+        ~boxSizing="border-box",
         ~fontFamily="inherit",
-        ~fontSize="16px",
+        ~fontSize=FontSize.md,
         ~border="none",
         ~backgroundColor=Color.transparent,
-        ~borderRadius="7px",
+        ~borderRadius=BorderRadius.default,
         (),
       )
     }
@@ -220,7 +232,7 @@ module DemoListSidebar = {
     let make = (~value, ~onChange, ~onClear) =>
       <div style=Styles.inputWrapper>
         <input style=Styles.input placeholder="Filter" value onChange />
-        {value === "" ? React.null : <ClearButton onClear />}
+        {value == "" ? React.null : <ClearButton onClear />}
       </div>
   }
 
@@ -277,15 +289,18 @@ module DemoListSidebar = {
                 </div>}
                 isDefaultOpen={isCategoryInQuery || !isCategoriesCollapsed}
                 isForceOpen={substring != ""}>
-                {renderMenu(
-                  ~parentCategoryHasSubstring=entityNameHasSubstring || parentCategoryHasSubstring,
-                  ~filterValue,
-                  ~nestingLevel=nestingLevel + 1,
-                  ~categoryQuery=`&category${levelStr}=` ++
-                  entityName->Js.Global.encodeURIComponent ++
-                  categoryQuery,
-                  demos,
-                )}
+                <PaddedBox padding=LeftRight>
+                  {renderMenu(
+                    ~parentCategoryHasSubstring=entityNameHasSubstring ||
+                    parentCategoryHasSubstring,
+                    ~filterValue,
+                    ~nestingLevel=nestingLevel + 1,
+                    ~categoryQuery=`&category${levelStr}=` ++
+                    entityName->Js.Global.encodeURIComponent ++
+                    categoryQuery,
+                    demos,
+                  )}
+                </PaddedBox>
               </Collapsible>
             </PaddedBox>
           } else {
@@ -305,32 +320,7 @@ module DemoListSidebar = {
     )
   }
 
-  let collapsedIcon =
-    <svg
-      width="20"
-      height="17"
-      viewBox="0 0 20 17"
-      fill=Color.darkGray
-      xmlns="http://www.w3.org/2000/svg">
-      <rect x="2" y="1" width="16" height="2" />
-      <rect x="2" y="7" width="16" height="2" />
-      <rect x="2" y="13" width="16" height="2" />
-    </svg>
 
-  let expandedIcon =
-    <svg
-      width="26"
-      height="17"
-      viewBox="0 0 26 17"
-      fill=Color.darkGray
-      xmlns="http://www.w3.org/2000/svg">
-      <rect x="6" y="1" width="16" height="2" />
-      <rect x="2" y="1" width="2" height="2" />
-      <rect x="10" y="7" width="12" height="2" />
-      <rect x="6" y="7" width="2" height="2" />
-      <rect x="10" y="13" width="12" height="2" />
-      <rect x="6" y="13" width="2" height="2" />
-    </svg>
 
   @react.component
   let make = (
@@ -349,11 +339,11 @@ module DemoListSidebar = {
               ~minWidth="32px",
               ~width="32px",
               ~cursor="pointer",
-              ~fontSize="14px",
+              ~fontSize=FontSize.sm,
               ~backgroundColor=Color.white,
               ~color=Color.darkGray,
               ~border=Border.default,
-              ~borderRadius="7px",
+              ~borderRadius=BorderRadius.default,
               ~margin="0",
               ~padding="0",
               ~display="flex",
@@ -366,13 +356,13 @@ module DemoListSidebar = {
               event->ReactEvent.Mouse.preventDefault
               onToggleCollapseCategories()
             }}>
-            {isCategoriesCollapsed ? collapsedIcon : expandedIcon}
+            {isCategoriesCollapsed ? Icon.categoryCollapsed : Icon.categoryExpanded}
           </button>
           <SearchInput
             value={filterValue->Option.getWithDefault("")}
             onChange={event => {
               let value = (event->ReactEvent.Form.target)["value"]
-              setFilterValue(_ => value->Js.String2.trim === "" ? None : Some(value))
+              setFilterValue(_ => value->Js.String2.trim == "" ? None : Some(value))
             }}
             onClear={() => setFilterValue(_ => None)}
           />
@@ -390,32 +380,35 @@ module DemoUnitSidebar = {
     let label = ReactDOM.Style.make(
       ~display="block",
       ~backgroundColor=Color.white,
-      ~borderRadius="7px",
+      ~borderRadius=BorderRadius.default,
       ~boxShadow="0 5px 10px rgba(0, 0, 0, 0.07)",
       (),
     )
-    let labelText = ReactDOM.Style.make(~fontSize="16px", ~textAlign="center", ())
+
+    let labelText = ReactDOM.Style.make(~fontSize=FontSize.md, ~textAlign="center", ())
+
     let textInput = ReactDOM.Style.make(
-      ~fontSize="16px",
+      ~fontSize=FontSize.md,
       ~width="100%",
       ~boxSizing="border-box",
       ~backgroundColor=Color.lightGray,
       ~boxShadow="inset 0 0 0 1px rgba(0, 0, 0, 0.1)",
       ~border="none",
       ~padding=Gap.md,
-      ~borderRadius="7px",
+      ~borderRadius=BorderRadius.default,
       (),
     )
+
     let select =
       ReactDOM.Style.make(
-        ~fontSize="16px",
+        ~fontSize=FontSize.md,
         ~width="100%",
         ~boxSizing="border-box",
         ~backgroundColor=Color.lightGray,
         ~boxShadow="inset 0 0 0 1px rgba(0, 0, 0, 0.1)",
         ~border="none",
         ~padding=Gap.md,
-        ~borderRadius="7px",
+        ~borderRadius=BorderRadius.default,
         ~appearance="none",
         ~paddingRight="30px",
         ~backgroundImage=`url("data:image/svg+xml,%3Csvg width='36' height='36' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='%2342484E' stroke-width='2' d='M12.246 14.847l5.826 5.826 5.827-5.826' fill='none' fill-rule='evenodd' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`,
@@ -424,7 +417,13 @@ module DemoUnitSidebar = {
         ~backgroundRepeat="no-repeat",
         (),
       )->ReactDOM.Style.unsafeAddProp("WebkitAppearance", "none")
-    let checkbox = ReactDOM.Style.make(~fontSize="16px", ~margin="0 auto", ~display="block", ())
+
+    let checkbox = ReactDOM.Style.make(
+      ~fontSize=FontSize.md,
+      ~margin="0 auto",
+      ~display="block",
+      (),
+    )
   }
 
   module PropBox = {
@@ -768,7 +767,7 @@ module App = {
       (),
     )
     let emptyText = ReactDOM.Style.make(
-      ~fontSize="22px",
+      ~fontSize=FontSize.lg,
       ~color=Color.black40a,
       ~textAlign="center",
       (),

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -237,7 +237,7 @@ module DemoListSidebar = {
   }
 
   let renderMenu = (
-    ~isCategoriesCollapsed: bool,
+    ~isCategoriesCollapsedByDefault: bool,
     ~urlSearchParams: URLSearchParams.t,
     ~filterValue,
     demos: Demos.t,
@@ -287,7 +287,7 @@ module DemoListSidebar = {
                 title={<div style=Styles.categoryName>
                   <HighlightSubstring text=entityName substring />
                 </div>}
-                isDefaultOpen={isCategoryInQuery || !isCategoriesCollapsed}
+                isDefaultOpen={isCategoryInQuery || !isCategoriesCollapsedByDefault}
                 isForceOpen={substring != ""}>
                 <PaddedBox padding=LeftRight>
                   {renderMenu(
@@ -324,8 +324,8 @@ module DemoListSidebar = {
   let make = (
     ~urlSearchParams: URLSearchParams.t,
     ~demos: Demos.t,
-    ~isCategoriesCollapsed: bool,
-    ~onToggleCollapsedCategories: unit => unit,
+    ~isCategoriesCollapsedByDefault: bool,
+    ~onToggleCollapsedCategoriesByDefault: unit => unit,
   ) => {
     let (filterValue, setFilterValue) = React.useState(() => None)
     <Sidebar fullHeight=true>
@@ -352,9 +352,9 @@ module DemoListSidebar = {
             title={"Toggle default collapsed categories"}
             onClick={event => {
               event->ReactEvent.Mouse.preventDefault
-              onToggleCollapsedCategories()
+              onToggleCollapsedCategoriesByDefault()
             }}>
-            {isCategoriesCollapsed ? Icon.categoryCollapsed : Icon.categoryExpanded}
+            {isCategoriesCollapsedByDefault ? Icon.categoryCollapsed : Icon.categoryExpanded}
           </button>
           <SearchInput
             value={filterValue->Option.getWithDefault("")}
@@ -367,7 +367,7 @@ module DemoListSidebar = {
         </div>
       </PaddedBox>
       <PaddedBox gap=Xxs>
-        {renderMenu(~isCategoriesCollapsed, ~filterValue, ~urlSearchParams, demos)}
+        {renderMenu(~isCategoriesCollapsedByDefault, ~filterValue, ~urlSearchParams, demos)}
       </PaddedBox>
     </Sidebar>
   }
@@ -823,18 +823,18 @@ module App = {
       None
     }, [showRightSidebar])
 
-    let (isCategoriesCollapsed, toggleIsCategoriesCollapsed) = React.useState(() => {
-      switch LocalStorage.localStorage->LocalStorage.getItem("isCategoriesCollapsed") {
+    let (isCategoriesCollapsedByDefault, toggleIsCategoriesCollapsed) = React.useState(() => {
+      switch LocalStorage.localStorage->LocalStorage.getItem("isCategoriesCollapsedByDefault") {
       | Some("true") => true
       | _ => false
       }
     })
 
-    let onToggleCollapsedCategories = () => {
-      toggleIsCategoriesCollapsed(_ => !isCategoriesCollapsed)
+    let onToggleCollapsedCategoriesByDefault = () => {
+      toggleIsCategoriesCollapsed(_ => !isCategoriesCollapsedByDefault)
       LocalStorage.localStorage->LocalStorage.setItem(
-        "isCategoriesCollapsed",
-        !isCategoriesCollapsed ? "true" : "false",
+        "isCategoriesCollapsedByDefault",
+        !isCategoriesCollapsedByDefault ? "true" : "false",
       )
     }
 
@@ -850,7 +850,10 @@ module App = {
         }
       | Demo(queryString) => <>
           <DemoListSidebar
-            demos urlSearchParams isCategoriesCollapsed onToggleCollapsedCategories
+            demos
+            urlSearchParams
+            isCategoriesCollapsedByDefault
+            onToggleCollapsedCategoriesByDefault
           />
           <div name="Content" style=Styles.right>
             <TopPanel
@@ -884,7 +887,10 @@ module App = {
         </>
       | Home => <>
           <DemoListSidebar
-            demos urlSearchParams isCategoriesCollapsed onToggleCollapsedCategories
+            demos
+            urlSearchParams
+            isCategoriesCollapsedByDefault
+            onToggleCollapsedCategoriesByDefault
           />
           <div style=Styles.empty>
             <div style=Styles.emptyText> {"Pick a demo"->React.string} </div>

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -7,6 +7,7 @@ module PaddedBox = ReshowcaseUi__Layout.PaddedBox
 module Stack = ReshowcaseUi__Layout.Stack
 module Sidebar = ReshowcaseUi__Layout.Sidebar
 module Icon = ReshowcaseUi__Layout.Icon
+module Collapsible = ReshowcaseUi__Layout.Collapsible
 module HighlightSubstring = ReshowcaseUi__Layout.HighlightSubstring
 module URLSearchParams = ReshowcaseUi__Bindings.URLSearchParams
 module Window = ReshowcaseUi__Bindings.Window
@@ -244,7 +245,7 @@ module DemoListSidebar = {
             style=Styles.link
             activeStyle=Styles.activeLink
             href={"?demo=" ++ entityName->Js.Global.encodeURIComponent ++ categoryQuery}
-            text=<HighlightSubstring text=entityName substring />
+            text={<HighlightSubstring text=entityName substring />}
           />
         } else {
           React.null
@@ -253,17 +254,22 @@ module DemoListSidebar = {
         if entityNameHasSubstring || Demos.hasNestedEntityWithSubstring(demos, substring) {
           let levelStr = Int.toString(level)
           <PaddedBox key={entityName} padding=LeftRight>
-            <div style=Styles.categoryName> <HighlightSubstring text=entityName substring />  </div>
-            {renderMenu(
-              ~filterValue,
-              ~nesting=(
-                level + 1,
-                `&category${levelStr}=` ++
-                entityName->Js.Global.encodeURIComponent ++
-                categoryQuery,
-              ),
-              demos,
-            )}
+            <Collapsible
+              title={<div style=Styles.categoryName>
+                <HighlightSubstring text=entityName substring />
+              </div>}
+              isDefaultOpen=false>
+              {renderMenu(
+                ~filterValue,
+                ~nesting=(
+                  level + 1,
+                  `&category${levelStr}=` ++
+                  entityName->Js.Global.encodeURIComponent ++
+                  categoryQuery,
+                ),
+                demos,
+              )}
+            </Collapsible>
           </PaddedBox>
         } else {
           React.null

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -304,6 +304,33 @@ module DemoListSidebar = {
     )
   }
 
+  let collapsedIcon =
+    <svg
+      width="20"
+      height="17"
+      viewBox="0 0 20 17"
+      fill=Color.darkGray
+      xmlns="http://www.w3.org/2000/svg">
+      <rect x="2" y="1" width="16" height="2" />
+      <rect x="2" y="7" width="16" height="2" />
+      <rect x="2" y="13" width="16" height="2" />
+    </svg>
+
+  let expandedIcon =
+    <svg
+      width="26"
+      height="17"
+      viewBox="0 0 26 17"
+      fill=Color.darkGray
+      xmlns="http://www.w3.org/2000/svg">
+      <rect x="6" y="1" width="16" height="2" />
+      <rect x="2" y="1" width="2" height="2" />
+      <rect x="10" y="7" width="12" height="2" />
+      <rect x="6" y="7" width="2" height="2" />
+      <rect x="10" y="13" width="12" height="2" />
+      <rect x="6" y="13" width="2" height="2" />
+    </svg>
+
   @react.component
   let make = (
     ~urlSearchParams: URLSearchParams.t,
@@ -338,7 +365,7 @@ module DemoListSidebar = {
               event->ReactEvent.Mouse.preventDefault
               onToggleCollapseCategories()
             }}>
-            {Collapsible.triangleIcon(!isCategoriesCollapsed)}
+            {isCategoriesCollapsed ? collapsedIcon : expandedIcon}
           </button>
           <SearchInput
             value={filterValue->Option.getWithDefault("")}

--- a/src/ReshowcaseUi__Bindings.res
+++ b/src/ReshowcaseUi__Bindings.res
@@ -47,6 +47,5 @@ module LocalStorage = {
   @return(nullable) @send external getItem: (t, string) => option<string> = "getItem"
   @send external setItem: (t, string, string) => unit = "setItem"
   @send external removeItem: (t, string) => unit = "removeItem"
+  @val external localStorage: t = "localStorage"
 }
-
-@val external localStorage: LocalStorage.t = "localStorage"

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -171,3 +171,37 @@ module HighlightSubstring = {
       }
     }
 }
+
+module Collapsible = {
+  module Styles = {
+    let clickableArea = ReactDOM.Style.make(
+      ~display="flex",
+      ~cursor="pointer",
+      ~gridGap="2px",
+      ~alignItems="center",
+      (),
+    )
+  }
+
+  let triangleIcon = isOpen =>
+    <svg width="10" height="6" transform={isOpen ? "" : "rotate(-90)"}>
+      <polygon points="0,0  10,0  5,6" fill=Color.darkGray />
+    </svg>
+
+  @react.component
+  let make = (~title: React.element, ~isDefaultOpen: bool=false, ~children) => {
+    let (isOpen, setIsOpen) = React.useState(() => isDefaultOpen)
+
+    React.useEffect1(() => {
+      setIsOpen(_ => isDefaultOpen)
+      None
+    }, [isDefaultOpen])
+
+    <div>
+      <div style=Styles.clickableArea onClick={_event => setIsOpen(isOpen => !isOpen)}>
+        {triangleIcon(isOpen)} title
+      </div>
+      {isOpen ? children : React.null}
+    </div>
+  }
+}

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -10,9 +10,9 @@ module Color = {
 }
 
 module Gap = {
-  let xxs = "3px"
-  let xs = "7px"
-  let md = "10px"
+  let xxs = "2px"
+  let xs = "5px"
+  let md = "8px"
 
   type t = Xxs | Xs | Md
 
@@ -26,6 +26,16 @@ module Gap = {
 
 module Border = {
   let default = `1px solid ${Color.midGray}`
+}
+
+module BorderRadius = {
+  let default = "5px"
+}
+
+module FontSize = {
+  let sm = "12px"
+  let md = "14px"
+  let lg = "20px"
 }
 
 module PaddedBox = {
@@ -140,6 +150,33 @@ module Icon = {
         fill="gray"
         d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
       />
+    </svg>
+
+  let categoryCollapsed =
+    <svg
+      width="20"
+      height="17"
+      viewBox="0 0 20 17"
+      fill=Color.darkGray
+      xmlns="http://www.w3.org/2000/svg">
+      <rect x="2" y="1" width="16" height="2" />
+      <rect x="2" y="7" width="16" height="2" />
+      <rect x="2" y="13" width="16" height="2" />
+    </svg>
+
+  let categoryExpanded =
+    <svg
+      width="26"
+      height="17"
+      viewBox="0 0 26 17"
+      fill=Color.darkGray
+      xmlns="http://www.w3.org/2000/svg">
+      <rect x="6" y="1" width="16" height="2" />
+      <rect x="2" y="1" width="2" height="2" />
+      <rect x="10" y="7" width="12" height="2" />
+      <rect x="6" y="7" width="2" height="2" />
+      <rect x="10" y="13" width="12" height="2" />
+      <rect x="6" y="13" width="2" height="2" />
     </svg>
 }
 

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -189,14 +189,14 @@ module Collapsible = {
     </svg>
 
   @react.component
-  let make = (~title: React.element, ~isDefaultOpen: bool=false, ~children) => {
+  let make = (~title: React.element, ~isDefaultOpen: bool=false, ~isForceOpen=false, ~children) => {
     let (isOpen, setIsOpen) = React.useState(() => isDefaultOpen)
 
     <div>
       <div style=Styles.clickableArea onClick={_event => setIsOpen(isOpen => !isOpen)}>
         {triangleIcon(isOpen)} title
       </div>
-      {isOpen ? children : React.null}
+      {isForceOpen || isOpen ? children : React.null}
     </div>
   }
 }

--- a/src/ReshowcaseUi__Layout.res
+++ b/src/ReshowcaseUi__Layout.res
@@ -192,11 +192,6 @@ module Collapsible = {
   let make = (~title: React.element, ~isDefaultOpen: bool=false, ~children) => {
     let (isOpen, setIsOpen) = React.useState(() => isDefaultOpen)
 
-    React.useEffect1(() => {
-      setIsOpen(_ => isDefaultOpen)
-      None
-    }, [isDefaultOpen])
-
     <div>
       <div style=Styles.clickableArea onClick={_event => setIsOpen(isOpen => !isOpen)}>
         {triangleIcon(isOpen)} title


### PR DESCRIPTION
## Description

- Add `Collapsible` component and use it in the left panel/demo menu to make collapsible sections and make tidy look.
- Add the button next to search filter to change the default behavior of categories after loading Reshowcase: collapsed or opened.
- Improve UX of search filter.
- Tune styles:
  - Make menu items more compact.
  - Decrease contrast of selected demo (big blue rectangle is too distracting when looking at the menu).
 - Add `FontSIze` and `BorderRadius` modules and use constants from there.

![image](https://user-images.githubusercontent.com/31879115/138336521-dadd98d9-0932-4d7c-9703-f7b5d2eceb1c.png)
 
## Preview:

https://reshowcase-eia3rvyzc-strelkovdd.vercel.app/