### PR TITLE
Properly shut down dev server on interrupt

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -130,19 +130,19 @@ if (isBuild) {
     ...(config.devServer || {})
   });
 
-  if (config.devServer && config.devServer.socket) {
-    ['SIGINT', 'SIGTERM'].forEach((signal) => {
-      process.on(signal, () => {
-        if (server) {
-          server.close(() => {
-            process.exit();
-          })
-        } else {
+  ['SIGINT', 'SIGTERM'].forEach((signal) => {
+    process.on(signal, () => {
+      if (server) {
+        server.close(() => {
           process.exit();
-        }
-      })
-    });
+        })
+      } else {
+        process.exit();
+      }
+    })
+  });
 
+  if (config.devServer && config.devServer.socket) {
     server.listen(config.devServer.socket);
   } else {
     server.listen(port, "0.0.0.0");

--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -131,6 +131,18 @@ if (isBuild) {
   });
 
   if (config.devServer && config.devServer.socket) {
+    ['SIGINT', 'SIGTERM'].forEach((signal) => {
+      process.on(signal, () => {
+        if (server) {
+          server.close(() => {
+            process.exit();
+          })
+        } else {
+          process.exit();
+        }
+      })
+    });
+
     server.listen(config.devServer.socket);
   } else {
     server.listen(port, "0.0.0.0");


### PR DESCRIPTION
## Description
Properly shut down dev server on interrupt.
This way, we leave webpack-dev-server to do its housekeeping before exiting. Prior to this, starting Reshowcase after terminating a previous instance would result in EADDRINUSE, and devs having to manually delete the socket file.

Another way was to intercept EADDRINUSE and check if the socket is still open and listening, like https://github.com/webpack/webpack-dev-server/blob/v3.11.2/bin/webpack-dev-server.js#L119-L141
But this is sub-optimal.


## Credits
[Original PR](https://github.com/ahrefs/reshowcase/pull/2) and changes made by @bryanthomaschen, I just cherry-picked commits from his branch from the fork.
The work was performed on behalf of [Ahrefs](https://ahrefs.com/) open-source work day.