### PR TITLE
Update command to propagate user errors

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -81,7 +81,12 @@ let config;
 try {
   config = require(path.join(process.cwd(), ".reshowcase/config.js"));
 } catch (err) {
-  config = {};
+  if (err.code == "MODULE_NOT_FOUND" && err.requireStack && err.requireStack.length == 1) {
+    config = {};
+  } else {
+    // Some error on custom `.reshowcase/config.js` file, let it through to let user know
+    throw err;
+  }
 }
 
 const compiler = webpack({


### PR DESCRIPTION
Previous implementation would swallow any errors on the custom `.reshowcase/config.js` provided by user. This change checks for error type to only ignore `MODULE_NOT_FOUND` with `requireStack` of length 1 (more length than that means what failed is a `require` on the custom config file).