### PR TITLE
Use prod mode when isBuild is true

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -88,7 +88,7 @@ const compiler = webpack({
   // https://github.com/webpack/webpack-dev-server/issues/2758#issuecomment-813135032
   // target: "web" (probably) can be removed after upgrading to webpack-dev-server v4
   target: "web",
-  mode: "development",
+  mode: isBuild ? "production" : "development",
   entry: {
     index: entryPath,
   },


### PR DESCRIPTION
This helps reducing the size and complexity of all JS assets involved in reshowcase, which is helpful in cases where tests are run against reshowcase using headless browsers, as it reduces the chances of crashing Chromium Renderer.