### PR TITLE
Read `config.cjs` in ES modules mode

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -77,12 +77,26 @@ const outputPath = (() => {
   }
 })();
 
-let config;
-try {
-  config = require(path.join(process.cwd(), ".reshowcase/config.js"));
-} catch (err) {
-  config = {};
-}
+const config = (() => {
+  const configDir = path.join(process.cwd(), ".reshowcase");
+  const configFilenames = fs.readdirSync(configDir);
+  const configFilename = configFilenames.find(
+    (filename) => filename === "config.cjs" || filename === "config.js"
+  );
+
+  if (configFilename === undefined) {
+    return {};
+  } else {
+    try {
+      const pathToConfig = path.join(configDir, configFilename);
+      const config_ = require(pathToConfig);
+      return config_;
+    } catch (error) {
+      console.error("Failed to read config:", error);
+      return {};
+    }
+  }
+})();
 
 const compiler = webpack({
   // https://github.com/webpack/webpack-dev-server/issues/2758#issuecomment-813135032

--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -79,21 +79,25 @@ const outputPath = (() => {
 
 const config = (() => {
   const configDir = path.join(process.cwd(), ".reshowcase");
-  const configFilenames = fs.readdirSync(configDir);
-  const configFilename = configFilenames.find(
-    (filename) => filename === "config.cjs" || filename === "config.js"
-  );
 
-  if (configFilename === undefined) {
+  if (!fs.existsSync(configDir)) {
     return {};
   } else {
-    try {
-      const pathToConfig = path.join(configDir, configFilename);
-      const config_ = require(pathToConfig);
-      return config_;
-    } catch (error) {
-      console.error("Failed to read config:", error);
+    const configFilenames = fs.readdirSync(configDir);
+    const configFilename = configFilenames.find(
+      (filename) => filename === "config.cjs" || filename === "config.js"
+    );
+    if (configFilename === undefined) {
       return {};
+    } else {
+      try {
+        const pathToConfig = path.join(configDir, configFilename);
+        const config_ = require(pathToConfig);
+        return config_;
+      } catch (error) {
+        console.error("Failed to read config:", error);
+        return {};
+      }
     }
   }
 })();
@@ -169,16 +173,16 @@ if (isBuild) {
     ...(config.devServer || {}),
   });
 
-  ['SIGINT', 'SIGTERM'].forEach((signal) => {
+  ["SIGINT", "SIGTERM"].forEach((signal) => {
     process.on(signal, () => {
       if (server) {
         server.close(() => {
           process.exit();
-        })
+        });
       } else {
         process.exit();
       }
-    })
+    });
   });
 
   if (config.devServer && config.devServer.socket) {


### PR DESCRIPTION
## Description

I've added support to read config from javascript file with `.cjs` extension.
This is needed if we use Reshowcase in a node environment running with ES modules support. 

## Credits

This change is done on behalf of [Ahrefs](https://ahrefs.com).